### PR TITLE
Build minimal example

### DIFF
--- a/data_adapter_oemof/adapters.py
+++ b/data_adapter_oemof/adapters.py
@@ -1,22 +1,27 @@
 import dataclasses
 
 from oemof.tabular import facades
+from oemof.solph import Bus
 
 from data_adapter_oemof import calculations
 from data_adapter_oemof.mappings import Mapper
 
 
-def not_build_solph_components(cls):
+def facade_adapter(cls):
     r"""
+    Sets type of Busses to str
     Sets 'build_solph_components' to False in __init__.
     """
+    # set type of bus to str
+    for field in dataclasses.fields(cls):
+        if field.type == Bus:
+            field.type = str
+
     original_init = cls.__init__
 
-    def new_init(self, *args, **kwargs):
-
-        kwargs["build_solph_components"] = False
-
-        original_init(self, *args, **kwargs)
+    # do not build solph components
+    def new_init(*args, **kwargs):
+        original_init(*args, build_solph_components=False, **kwargs)
 
     cls.__init__ = new_init
 
@@ -30,34 +35,35 @@ def get_default_mappings(cls, mapper):
     return dictionary
 
 
-@not_build_solph_components
+@facade_adapter
 class CommodityAdapter(facades.Commodity):
     def parametrize_dataclass(self, data):
         instance = self.datacls()
         return instance
 
 
+@facade_adapter
 class ConversionAdapter(facades.Conversion):
     def parametrize_dataclass(self, data):
         instance = self.datacls()
         return instance
 
 
-@not_build_solph_components
+@facade_adapter
 class LoadAdapter(facades.Load):
     def parametrize_dataclass(self, data):
         instance = self.datacls()
         return instance
 
 
-@not_build_solph_components
+@facade_adapter
 class StorageAdapter(facades.Storage):
     def parametrize_dataclass(self, data):
         instance = self.datacls()
         return instance
 
 
-@not_build_solph_components
+@facade_adapter
 class VolatileAdapter(facades.Volatile):
     @classmethod
     def parametrize_dataclass(cls, data):

--- a/data_adapter_oemof/build_datapackage.py
+++ b/data_adapter_oemof/build_datapackage.py
@@ -1,0 +1,35 @@
+import os
+
+import pandas as pd
+
+from data_adapter_oemof.adapters import TYPE_MAP
+from data_adapter_oemof.mappings import PROCESS_TYPE_MAP
+
+
+def build_datapackage(**process_data):
+    parametrized = {}
+    for process, data in process_data.items():
+
+        process_type = PROCESS_TYPE_MAP[process]
+
+        adapter = TYPE_MAP[process_type]
+
+        paramet = adapter.parametrize_dataclass(data)
+
+        if process_type not in parametrized:
+            parametrized[process_type] = []
+
+        parametrized[process_type].append(paramet)
+
+    # create a dictionary of dataframes
+    datapackage = {
+        type: pd.DataFrame(adapted) for type, adapted in parametrized.items()
+    }
+
+    return datapackage
+
+
+def save_datapackage_to_csv(datapackage, destination):
+    for key, value in datapackage.items():
+        file_path = os.path.join(destination, key + ".csv")
+        value.to_csv(file_path)

--- a/data_adapter_oemof/calculations.py
+++ b/data_adapter_oemof/calculations.py
@@ -1,9 +1,31 @@
+import warnings
+
 from oemof.tools.economics import annuity
 
 
+def calculation(func):
+    r"""
+    This is a decorator that allows calculations to fail
+    """
+
+    def decorated_func(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            warnings.warn(
+                f"Calculation function '{func.__name__}' \n"
+                f"called with {args, kwargs} \n"
+                f"failed because of: \n" + str(e)
+            )
+
+    return decorated_func
+
+
+@calculation
 def get_name(region, carrier, tech):
     return f"{region}-{carrier}-{tech}"
 
 
+@calculation
 def get_capacity_cost(overnight_cost, fixed_cost, lifetime, wacc):
     return annuity(overnight_cost, lifetime, wacc) + fixed_cost

--- a/data_adapter_oemof/calculations.py
+++ b/data_adapter_oemof/calculations.py
@@ -10,13 +10,14 @@ def calculation(func):
 
     def decorated_func(*args, **kwargs):
         try:
-            func(*args, **kwargs)
-        except Exception as e:
+            return func(*args, **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
             warnings.warn(
                 f"Calculation function '{func.__name__}' \n"
                 f"called with {args, kwargs} \n"
                 f"failed because of: \n" + str(e)
             )
+            return None
 
     return decorated_func
 

--- a/data_adapter_oemof/mappings.py
+++ b/data_adapter_oemof/mappings.py
@@ -21,7 +21,7 @@ class Mapper:
             logger.info(f"Key not found. Did not map '{key}'")
 
         if mapped_key not in self.data:
-            logger.warning("Could not get key")
+            logger.warning(f"Could not get data for mapped key '{mapped_key}'")
             return None
 
         return self.data[mapped_key]

--- a/data_adapter_oemof/mappings.py
+++ b/data_adapter_oemof/mappings.py
@@ -51,3 +51,7 @@ TECH_MAP = {
 GLOBAL_PARAMETER_MAP = load_yaml(
     Path(__file__).parent / "mappings" / "GLOBAL_PARAMETER_MAP.yaml"
 )
+
+PROCESS_TYPE_MAP = load_yaml(
+    Path(__file__).parent / "mappings" / "PROCESS_TYPE_MAP.yaml"
+)

--- a/data_adapter_oemof/mappings/GLOBAL_PARAMETER_MAP.yaml
+++ b/data_adapter_oemof/mappings/GLOBAL_PARAMETER_MAP.yaml
@@ -1,6 +1,6 @@
-capacity: sedos-capacity
+capacity: installed_capacity
 marginal_cost: sedos-marginal_cost
-overnight_cost: sedos-overnight_cost
-fixed_cost: sedos-fixed_cost
-lifetime: sedos-lifetime
+overnight_cost: capital_costs
+fixed_cost: fixed_costs
+lifetime: lifetime
 wacc: sedos-wacc

--- a/data_adapter_oemof/mappings/PROCESS_TYPE_MAP.yaml
+++ b/data_adapter_oemof/mappings/PROCESS_TYPE_MAP.yaml
@@ -1,0 +1,1 @@
+offshore wind farm: volatile

--- a/tests/test_data_adapter.py
+++ b/tests/test_data_adapter.py
@@ -59,12 +59,6 @@ def test_adapter():
 
         df_default = pd.read_csv(path_default, sep=";")
 
-        # assert set(df.columns) == set(df_default.columns)
+        assert set(df.columns) == set(df_default.columns)
 
-        print(df)
-        print(df_default)
-
-        # pd.testing.assert_frame_equal(df, df_default)
-
-
-test_adapter()
+        pd.testing.assert_frame_equal(df, df_default)

--- a/tests/test_databus_connection.py
+++ b/tests/test_databus_connection.py
@@ -1,15 +1,11 @@
-import os
-
 from data_adapter.databus import download_collection
-from data_adapter_oemof import settings
 
 
 def test_download_collection():
-    collection_url = "https://energy.databus.dbpedia.org/felixmaur/collections/modex_test_renewable"
-    collection_output_directory=settings.COLLECTIONS_DIR
-    if not os.path.exists(collection_output_directory):
-        os.makedirs(collection_output_directory)
+    collection_url = (
+        "https://energy.databus.dbpedia.org/felixmaur/collections/modex_test_renewable"
+    )
+
     download_collection(
         collection_url=collection_url,
-        collection_output_directory=collection_output_directory,
     )

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,13 +1,20 @@
 from data_adapter.preprocessing import get_process_df
 from data_adapter.structure import get_energy_structure
-from oemof.solph.helpers import extend_basic_path
 
+from utils import PATH_TEST_FILES, PATH_TMP, check_if_csv_dirs_equal
 from data_adapter_oemof.build_datapackage import (
     build_datapackage,
     save_datapackage_to_csv,
 )
 
-tmp_path = extend_basic_path("data_adatper_oemof")
+
+path_default = (
+    PATH_TEST_FILES
+    / "_files"
+    / "tabular_datapackage_mininmal_example"
+    / "data"
+    / "elements"
+)
 
 
 def test_build_tabular_datapackage():
@@ -27,4 +34,6 @@ def test_build_tabular_datapackage():
 
     datapackage = build_datapackage(**process_data)
 
-    save_datapackage_to_csv(datapackage, tmp_path)
+    save_datapackage_to_csv(datapackage, PATH_TMP)
+
+    check_if_csv_dirs_equal(PATH_TMP, path_default)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,9 +1,13 @@
-from data_adapter.structure import get_energy_structure
 from data_adapter.preprocessing import get_process_df
+from data_adapter.structure import get_energy_structure
+from oemof.solph.helpers import extend_basic_path
 
+from data_adapter_oemof.build_datapackage import (
+    build_datapackage,
+    save_datapackage_to_csv,
+)
 
-from data_adapter_oemof.adapters import TYPE_MAP
-from data_adapter_oemof.mappings import PROCESS_TYPE_MAP
+tmp_path = extend_basic_path("data_adatper_oemof")
 
 
 def test_build_tabular_datapackage():
@@ -16,11 +20,11 @@ def test_build_tabular_datapackage():
     # all necessary information.
     processes = ["offshore wind farm"]
 
-    for process in processes:
-        data = get_process_df("modex_test_renewable", process)
+    process_data = {
+        process: get_process_df("modex_test_renewable", process)
+        for process in processes
+    }
 
-        process_type = PROCESS_TYPE_MAP[process]
+    datapackage = build_datapackage(**process_data)
 
-        adapter = TYPE_MAP[process_type]
-
-        p = adapter.parametrize_dataclass(data)
+    save_datapackage_to_csv(datapackage, tmp_path)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,26 @@
+from data_adapter.structure import get_energy_structure
+from data_adapter.preprocessing import get_process_df
+
+
+from data_adapter_oemof.adapters import TYPE_MAP
+from data_adapter_oemof.mappings import PROCESS_TYPE_MAP
+
+
+def test_build_tabular_datapackage():
+
+    es_structure = get_energy_structure()
+
+    processes = es_structure.keys()
+
+    # This is a placeholder as long as get_energy_structure does not provide
+    # all necessary information.
+    processes = ["offshore wind farm"]
+
+    for process in processes:
+        data = get_process_df("modex_test_renewable", process)
+
+        process_type = PROCESS_TYPE_MAP[process]
+
+        adapter = TYPE_MAP[process_type]
+
+        p = adapter.parametrize_dataclass(data)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,103 @@
+import os
+import pathlib
+
+import pandas as pd
+from oemof.solph.helpers import extend_basic_path
+
+PATH_TEST_FILES = pathlib.Path(__file__).parent
+
+PATH_TMP = extend_basic_path("data_adapter_oemof")
+
+
+def get_all_file_paths(dir):
+    r"""
+    Finds all paths of files in a directory.
+
+    Parameters
+    ----------
+    dir : str
+        Directory
+
+    Returns
+    -------
+    file_paths : list
+        list of str
+    """
+    # pylint: disable=unused-variable
+    file_paths = []
+    for dir_path, dir_names, file_names in os.walk(dir):
+        for file_name in file_names:
+            file_paths.append(os.path.join(dir_path, file_name))
+
+    return file_paths
+
+
+def check_if_csv_files_equal(csv_file_a, csv_file_b):
+    r"""
+    Compares two csv files.
+
+    Parameters
+    ----------
+    csv_file_a
+    csv_file_b
+
+    """
+    df1 = pd.read_csv(csv_file_a)
+    df2 = pd.read_csv(csv_file_b)
+
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def check_if_csv_dirs_equal(dir_a, dir_b):
+    r"""
+    Compares the csv files in two directories and asserts that
+    they are equal.
+
+    The function asserts that:
+
+    1. The file names of csv files found in the directories are the same.
+    2. The file contents are the same.
+
+    Parameters
+    ----------
+    dir_a : str
+        Path to first directory containing csv files
+
+    dir_b : str
+        Path to second directory containing csv files
+
+    """
+    files_a = get_all_file_paths(dir_a)
+    files_b = get_all_file_paths(dir_b)
+
+    files_a = [file for file in files_a if file.split(".")[-1] == "csv"]
+    files_b = [file for file in files_b if file.split(".")[-1] == "csv"]
+
+    files_a.sort()
+    files_b.sort()
+
+    f_names_a = [os.path.split(f)[-1] for f in files_a]
+    f_names_b = [os.path.split(f)[-1] for f in files_b]
+
+    diff = list(set(f_names_a).symmetric_difference(set(f_names_b)))
+
+    assert not diff, f"Lists of filenames are not the same." f" The diff is: {diff}"
+
+    for file_a, file_b in zip(files_a, files_b):
+        try:
+            check_if_csv_files_equal(file_a, file_b)
+        except AssertionError:
+            diff.append([file_a, file_b])
+
+    if diff:
+        error_message = ""
+        for pair in diff:
+            short_name_a, short_name_b = (
+                os.path.join(*f.split(os.sep)[-4:]) for f in pair
+            )
+            line = " - " + short_name_a + " and " + short_name_b + "\n"
+            error_message += line
+
+        raise AssertionError(
+            f" The contents of these file are different:\n{error_message}"
+        )


### PR DESCRIPTION
Adds a test that aims to reproduce the minimal example datapackage in tests/_files/tabular_datapackage_minimal_example.

Problems:
* [x] how to know which adapters belong to the process. Solved by introducing a mapping.
* [ ] get_energy_structure() does not yield a complete list of processes
* [ ] how to get data for wacc?
* [ ] The example data contains different regions with varying completeness of data