### PR TITLE
Only returning found values

### DIFF
--- a/data_adapter_oemof/mappings.py
+++ b/data_adapter_oemof/mappings.py
@@ -88,7 +88,9 @@ class Mapper:
         :return: Dictionary for all fields that the facade can take and matching data
         """
         mapped_all_class_fields = {
-            field.name: self.get(field.name) for field in dataclasses.fields(cls)
+            field.name: value
+            for field in dataclasses.fields(cls)
+            if (value := self.get(field.name)) is not None
         }
         mapped_all_class_fields.update(self.get_busses(cls, struct))
         return mapped_all_class_fields


### PR DESCRIPTION
Update to `get_default_mappings` that is now only returning found values. This will lead to errors until #13 is implemented and is successfully adding profile values to the facade since volatile facade fails without profile or other "minimal required" values within the facade. 