### PR TITLE
Write scalars as scalars and not as lists

### DIFF
--- a/data_adapter_oemof/build_datapackage.py
+++ b/data_adapter_oemof/build_datapackage.py
@@ -80,9 +80,15 @@ def _listify_to_periodic(group_df) -> pd.Series:
                 )  # throw out the index
             values = group_df[col].unique()
         if len(values) > 1:
-            unique_values[col] = list(group_df[col])
+            if isinstance(group_df[col].iloc[0], list):
+                unique_values[col] = list(group_df[col].apply(lambda x: x[0]))
+            else:
+                unique_values[col] = list(group_df[col])
         else:
-            unique_values[col] = group_df[col].iloc[0]
+            if isinstance(group_df[col].iloc[0], list):
+                unique_values[col] = group_df[col].iat[0][0]
+            else:
+                unique_values[col] = group_df[col].iat[0]
     unique_values["name"] = "_".join(group_df.name)
     unique_values.drop("year")
     return unique_values


### PR DESCRIPTION
In my current AP8 dataset I use, scalars are returns as list of scalar and also passed as list of scalars to tabular. which doesnt work.


this is a fix. I am not sure if this is actually necesary as @henhuy maybe already takes care of this in data_adapter